### PR TITLE
Ask for project mode before opening editor and additional window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+history

--- a/load_project.py
+++ b/load_project.py
@@ -97,13 +97,16 @@ def main(args: List[str]) -> tuple[str, bool]:
     # from kittens.tui.loop import debug
     # debug(selection)
 
-    answer = input('Start in project mode? [y,N] >')
-    if answer.upper() == 'Y':
-        answer = True
-    else:
-        answer = False
+    as_project = False
 
-    return (selection, answer)
+    if selection not in tabs:
+        as_project = input('Start in project mode? [y,N] >')
+        if as_project.upper() == 'Y':
+            as_project = True
+        else:
+            as_project = False
+
+    return (selection, as_project)
 
 
 def handle_result(


### PR DESCRIPTION
* adds an additional input to ask if a project should be opened in _project mode_ and only then opens v$EDITOR and an additional window
* fixes the path of the additional window: 'current' opens it in the cwd of the calling window, not of the parent window - at least here